### PR TITLE
fix: avoid duplicate document click handlers

### DIFF
--- a/prompt-selector.js
+++ b/prompt-selector.js
@@ -3,7 +3,10 @@
 (function() {
     // Make prompt selector functions available globally
     window.MyShowsPromptSelector = window.MyShowsPromptSelector || {};
-    
+
+    // Keep track of the document click handler so we don't attach duplicates
+    let documentClickHandler = null;
+
     // Set up the prompt selector dropdown
     MyShowsPromptSelector.setupPromptSelector = function() {
         const selectorButton = document.getElementById('prompt-selector-button');
@@ -115,12 +118,19 @@
             }
         });
 
-        // Close dropdown when clicking outside
-        document.addEventListener('click', function (e) {
+        // Close dropdown when clicking outside. Remove previous handler if any to
+        // avoid stacking multiple listeners when the UI is re-rendered.
+        if (documentClickHandler) {
+            document.removeEventListener('click', documentClickHandler);
+        }
+
+        documentClickHandler = function (e) {
             if (!dropdown.contains(e.target) && !selectorButton.contains(e.target)) {
                 dropdown.style.display = 'none';
             }
-        });
+        };
+
+        document.addEventListener('click', documentClickHandler);
     };
     
     console.debug("MyShows Comment Summarizer prompt selector loaded");


### PR DESCRIPTION
## Summary
- prevent multiple document-level click handlers in the prompt selector
- track and clean up the existing handler before adding a new one

## Testing
- `for f in *.js; do node --check "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68a3ec80393c8323a5e892f783a207c5