### PR TITLE
Use max_completion_tokens for gpt-5 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ You can customize the extension by clicking its icon in the toolbar:
 - **GPT-4.1**: Flagship GPT model for complex tasks
 - **GPT-4o mini**: Fast, affordable small model for focused tasks
 - **GPT-4.1 mini**: Balanced for intelligence, speed, and cost
+- **GPT-5**: Most advanced model for complex tasks
+- **GPT-5 mini**: Compact GPT-5 model for fast, affordable tasks
+- **GPT-5 nano**: Smallest GPT-5 model for ultra-low latency tasks
 - **o4-mini**: Faster, more affordable reasoning model
 
 ### Summary Language

--- a/summarizer.js
+++ b/summarizer.js
@@ -183,7 +183,13 @@
                                 {role: 'system', content: systemMessage},
                                 {role: 'user', content: userMessage}
                             ],
-                            ...(model === 'o4-mini' ? { max_completion_tokens: maxTokens } : { temperature: temperature, max_tokens: maxTokens })
+                            ...(
+                                model === 'o4-mini'
+                                    ? { max_completion_tokens: maxTokens }
+                                    : model.startsWith('gpt-5')
+                                        ? { temperature: temperature, max_completion_tokens: maxTokens }
+                                        : { temperature: temperature, max_tokens: maxTokens }
+                            )
                         })
                     })
                         .then(response => {

--- a/tests/generateSummary.test.js
+++ b/tests/generateSummary.test.js
@@ -1,0 +1,50 @@
+const { JSDOM } = require('jsdom');
+
+describe('MyShowsSummarizer.generateSummary', () => {
+  test('uses max_completion_tokens for gpt-5 models', async () => {
+    const dom = new JSDOM('<!DOCTYPE html><p>test</p>');
+    global.window = dom.window;
+    global.document = dom.window.document;
+
+    // Prepare globals required by summarizer.js
+    dom.window.eval('var MyShowsSummarizer = {}; window.MyShowsSummarizer = MyShowsSummarizer;');
+    dom.window.eval(`var MyShowsPrompts = { systemPrompt: '', userPrompts: { default: () => 'prompt' } }; window.MyShowsPrompts = MyShowsPrompts;`);
+
+    // Mock chrome.storage.sync.get
+    global.chrome = {
+      storage: {
+        sync: {
+          get: (_defaults, callback) => {
+            callback({
+              openaiApiKey: 'test-key',
+              selectedModel: 'gpt-5',
+              summaryLanguage: 'english',
+              temperature: 0.5,
+              maxTokens: 100
+            });
+          }
+        }
+      }
+    };
+
+    // Mock fetch
+    const fetchMock = jest.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ choices: [{ message: { content: 'ok' } }] })
+    }));
+    global.fetch = fetchMock;
+
+    // Load summarizer script
+    const fs = require('fs');
+    const path = require('path');
+    const scriptContent = fs.readFileSync(path.resolve(__dirname, '../summarizer.js'), 'utf-8');
+    dom.window.eval(scriptContent);
+
+    const comments = [{ text: 'hi', rating: '5' }];
+    await dom.window.MyShowsSummarizer.generateSummary(comments, 'default');
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.max_completion_tokens).toBe(100);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+});


### PR DESCRIPTION
## Summary
- Pass `max_completion_tokens` to Chat Completions when using any `gpt-5` family model
- Document gpt-5 model options in README
- Add test verifying gpt-5 requests include `max_completion_tokens`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a55987468c832389be180702c9d26f